### PR TITLE
build: update google-github-actions/setup-gcloud from master to v0

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -23,7 +23,7 @@ runs:
         echo "IMAGE_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
         echo "VERSION=$DOCKER_IMAGE_VERSION" >> $GITHUB_ENV
 
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@v0
       with:
         version: "270.0.0"
         service_account_email: ${{ inputs.gcloud-email }}


### PR DESCRIPTION
## Description
Fix for:

Error: On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.

We strongly advise updating your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'

<!-- ## Note --> 

## Test  
- [ ] unit test  
- [ ] integration test
