### PR TITLE
feat(ci): add docker build with auth

### DIFF
--- a/.github/actions/docker-build-v2/action.yml
+++ b/.github/actions/docker-build-v2/action.yml
@@ -1,0 +1,51 @@
+name: Build and publish image
+
+description: Builds and pushes the Docker image.
+
+inputs:
+  gcloud-project:
+    description: "GCP project to use for the build"
+    required: true
+  gcloud-credentials:
+    description: "Credentials corresponding to the service account (json)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set env vars
+      shell: bash
+      run: |
+        echo "GCLOUD_PROJECT=${{ inputs.gcloud-project }}" >> $GITHUB_ENV
+        echo "IMAGE_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
+        echo "VERSION=$DOCKER_IMAGE_VERSION" >> $GITHUB_ENV
+
+    - name: 'auth'
+      uses: 'google-github-actions/auth@v0'
+      with:
+        credentials_json: "${{ inputs.gcloud-credentials }}"
+
+    - name: Setup Gcloud
+      uses: google-github-actions/setup-gcloud@v0
+
+    - name: Set up docker auth
+      shell: bash
+      run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker
+
+    # Build the Docker image
+    - name: Build
+      shell: bash
+      run: docker build --build-arg APP_VERSION=$VERSION -t image .
+
+    # Push the Docker image to Google Container Registry
+    - name: Publish
+      shell: bash
+      run: |
+        IMAGE_ID=gcr.io/$GCLOUD_PROJECT/$IMAGE_NAME
+        echo IMAGE_ID=$IMAGE_ID
+        echo VERSION=$VERSION
+        docker tag image $IMAGE_ID:$VERSION
+        docker push $IMAGE_ID:$VERSION


### PR DESCRIPTION
## Description
Ticket: [DEV-166](https://myos.atlassian.net/browse/DEV-166)

Create a new action `docker-build-v2` to stop using deprecated auth with `service_account_key` and `service_account_email` like in `docker-build`.
Reason I don't update the main action is that it's a breaking change (parameters of the action are not the same). Normally we would want to have all the workflows using our actions pointing at a tagged version so development can continue on main without breaking running configs. I plan on creating a release after the merge and then, while refactoring all CI pipelines, point at this version so this doesn't happen in the future.
