### PR TITLE
Dev 686 optimize ci

### DIFF
--- a/.github/actions/docker-build-v2/action.yml
+++ b/.github/actions/docker-build-v2/action.yml
@@ -39,15 +39,23 @@ runs:
         # via gcloud command-line tool.
         gcloud auth configure-docker
 
+    - name: Check if already an image built for the commit
+      shell: bash
+      run: |
+        CHECK_IMAGE_TAG=$(gcloud container images list-tags gcr.io/${GCLOUD_PROJECT}/${IMAGE_NAME} | grep "$COMMIT_HASH_SHORT" | awk '{ print $2}' | sed 's/,.*//' || true)
+        echo "CHECK_IMAGE_TAG=$CHECK_IMAGE_TAG" >> $GITHUB_ENV
+
     # Build the Docker image
     - name: Build
       shell: bash
       run: |
-        if [[ "$BUILD_ARGS" == "" ]]; then
-          docker build --build-arg APP_VERSION=$VERSION -t image .
-        else
-          docker_cmd="docker build $BUILD_ARGS -t image ."
-          $docker_cmd
+        if [[ "$CHECK_IMAGE_TAG" == "" ]]; then
+          if [[ "$BUILD_ARGS" == "" ]]; then
+            docker build --build-arg APP_VERSION=$VERSION -t image .
+          else
+            docker_cmd="docker build $BUILD_ARGS -t image ."
+            $docker_cmd
+          fi
         fi
       env:
         BUILD_ARGS: "${{ inputs.build-args }}"
@@ -59,5 +67,9 @@ runs:
         IMAGE_ID=gcr.io/$GCLOUD_PROJECT/$IMAGE_NAME
         echo IMAGE_ID=$IMAGE_ID
         echo VERSION=$VERSION
-        docker tag image $IMAGE_ID:$VERSION
-        docker push $IMAGE_ID:$VERSION
+        if [[ "$CHECK_IMAGE_TAG" == "" ]]; then
+          docker tag image $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+        else
+          gcloud container images add-tag -q  gcr.io/${GCLOUD_PROJECT}/${IMAGE_NAME}:${CHECK_IMAGE_TAG}  gcr.io/${GCLOUD_PROJECT}/${IMAGE_NAME}:$VERSION
+        fi

--- a/.github/actions/set-docker-metadata/action.yml
+++ b/.github/actions/set-docker-metadata/action.yml
@@ -21,6 +21,7 @@ runs:
         BRANCH=$(echo "${BRANCH_REF#refs/heads/}" | sed -e 's,.*/\(.*\),\1,')
         COMMIT_HASH_SHORT=$(git rev-parse --short "$SHA_REF")
         echo "_VERSION=$(echo $BRANCH'_'$COMMIT_HASH_SHORT)" >> $GITHUB_ENV
+        echo "_COMMIT_HASH_SHORT=$COMMIT_HASH_SHORT" >> $GITHUB_ENV
 
     - name: Generate version using tag
       shell: bash
@@ -54,4 +55,5 @@ runs:
       shell: bash
       run: |
         echo "DOCKER_IMAGE_VERSION=$_VERSION" >> $GITHUB_ENV
+        echo "COMMIT_HASH_SHORT=$_COMMIT_HASH_SHORT" >> $GITHUB_ENV
         echo "DOCKER_IMAGE_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV


### PR DESCRIPTION
## Description
Ticket: [DEV-686](https://myos.atlassian.net/browse/DEV-686)

- Set short version of commit hash as env var in `set-docker-metadata`
- Add step in `docker-build` to retrieve an image tagged with that hash
- If not, image is built and tagged
- If yes, image is not rebuilt and tag is added

This would for example avoid that an image is rebuilt following a merge of `develop` in `main` if the code is the same.

[DEV-686]: https://myos.atlassian.net/browse/DEV-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ