### PR TITLE
chore(template-pr): update default pr template to be more comprehensive

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,29 @@
 ## Description
-Ticket: [PLAT-000](https://myos.atlassian.net/browse/PLAT-000)  
 
-<!-- ## Note --> 
+Ticket: [PLAT-000](https://myos.atlassian.net/browse/PLAT-000)
 
-## Test  
+## Supporting info
 
-- [ ] unit test  
-- [ ] integration test
+Please include any supporting information reviewers may need in order to understand and provide feedback on this pull request.
+
+## Checklist
+
+- Tests
+  - [ ] Unit tests are included
+  - [ ] Integration tests  are included
+  - [ ] Tests cover the happy path
+  - [ ] Tests cover unhappy paths
+  - [ ] All tests pass
+- Documentation (select at least one)
+  - [ ] Changes are self-explanatory
+  - [ ] Comments are included
+  - [ ] External documentation has been written
+- Downstream effects (select one)
+  - [ ] There are no breaking changes
+  - [ ] Breaking changes are being coordinated with owners of affected servies
 
 ## Other PR templates
 
-Add the following query params to the current URL to use other PR templates:
+Add the following query params to the current URL to use a different pull request template, instead of this one:
 
 - Internal release notes: `?template=release.md`


### PR DESCRIPTION
## Description

Updated the default PR template to prompt for supporting information (if the code itself is not self-explanatory), and added a checklist for common things we would like to ensure are true or have occurred before merging.

Suggestions very much welcome, if you feel something is missing or could be different.