### PR TITLE
fix(setup-node): upgrade node action v3

### DIFF
--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -14,17 +14,11 @@ inputs:
 runs:
     using: 'composite'
     steps:
-        - uses: actions/setup-node@v1
+        - uses: actions/setup-node@v3
           with:
               node-version: ${{ inputs.node-version }}
               registry-url: 'https://npm.pkg.github.com'
-
-        - uses: actions/cache@v3
-          with:
-              path: ~/.npm
-              key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-              restore-keys: |
-                  ${{ runner.os }}-node-
+              cache: 'npm'
 
         - name: Install deps
           run: npm ci


### PR DESCRIPTION
V1 is essentially deprecated since it's running node v12.
V3 already have a builtin cache config so we just need to define which package manager to use.