### PR TITLE
feat(datadog): add dd api key to terraform action

### DIFF
--- a/.github/actions/terraform/action.yml
+++ b/.github/actions/terraform/action.yml
@@ -38,6 +38,12 @@ inputs:
   pritunl-secret:
     description: "Pritunl secret"
     required: true
+  datadog-api-key:
+    description: "Datadog API key"
+    required: true
+  datadog-app-key:
+    description: "Datadog APP key"
+    required: true
 
 runs:
   using: 'composite'
@@ -75,6 +81,8 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         TF_VAR_pritunl_token: ${{ inputs.pritunl-token }}
         TF_VAR_pritunl_secret: ${{ inputs.pritunl-secret }}
+        DD_API_KEY: ${{ inputs.datadog-api-key }}
+        DD_APP_KEY: ${{ inputs.datadog-app-key }}
 
     - name: Terraform fmt
       shell: bash
@@ -97,6 +105,8 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         TF_VAR_pritunl_token: ${{ inputs.pritunl-token }}
         TF_VAR_pritunl_secret: ${{ inputs.pritunl-secret }}
+        DD_API_KEY: ${{ inputs.datadog-api-key }}
+        DD_APP_KEY: ${{ inputs.datadog-app-key }}
 
     - name: Terraform apply
       shell: bash
@@ -110,3 +120,5 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         TF_VAR_pritunl_token: ${{ inputs.pritunl-token }}
         TF_VAR_pritunl_secret: ${{ inputs.pritunl-secret }}
+        DD_API_KEY: ${{ inputs.datadog-api-key }}
+        DD_APP_KEY: ${{ inputs.datadog-app-key }}


### PR DESCRIPTION
## Description

Ticket: [DEV-869](https://myos.atlassian.net/browse/DEV-869)

- Add datadog api key to be able to use datadog provider with our CD pipeline for infra repo

[DEV-869]: https://myos.atlassian.net/browse/DEV-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ