### PR TITLE
Dev 930 artifact registry

### DIFF
--- a/.github/actions/docker-build-v2/action.yml
+++ b/.github/actions/docker-build-v2/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "Build args for the docker image"
     required: false
     default: ''
+  registry:
+    description: "Location to push the docker image, container registry by default"
+    required: false
+    default: 'container'
 
 runs:
   using: "composite"
@@ -42,8 +46,14 @@ runs:
     - name: Check if already an image built for the commit
       shell: bash
       run: |
-        CHECK_IMAGE_TAG=$(gcloud container images list-tags gcr.io/${GCLOUD_PROJECT}/${IMAGE_NAME} | grep "$COMMIT_HASH_SHORT" | awk '{ print $2}' | sed 's/,.*//' | xargs || true)
+        if [[ "$REGISTRY" == "artifact" ]]; then
+          CHECK_IMAGE_TAG=$(gcloud container images list-tags europe-west3-docker.pkg.dev/${GCLOUD_PROJECT}/${IMAGE_NAME}/${IMAGE_NAME} | grep "$COMMIT_HASH_SHORT" | awk '{ print $2}' | sed 's/,.*//' | xargs || true)
+        else
+          CHECK_IMAGE_TAG=$(gcloud container images list-tags gcr.io/${GCLOUD_PROJECT}/${IMAGE_NAME} | grep "$COMMIT_HASH_SHORT" | awk '{ print $2}' | sed 's/,.*//' | xargs || true)
+        fi
         echo "CHECK_IMAGE_TAG=$CHECK_IMAGE_TAG" >> $GITHUB_ENV
+      env:
+        REGISTRY: "${{ inputs.registry }}"
 
     # Build the Docker image
     - name: Build
@@ -64,12 +74,20 @@ runs:
     - name: Publish
       shell: bash
       run: |
-        IMAGE_ID=gcr.io/$GCLOUD_PROJECT/$IMAGE_NAME
-        echo IMAGE_ID=$IMAGE_ID
-        echo VERSION=$VERSION
+        if [[ "$REGISTRY" == "artifact" ]]; then
+          IMAGE_ID=europe-west3-docker.pkg.dev/${GCLOUD_PROJECT}/${IMAGE_NAME}/${IMAGE_NAME}
+        else
+          IMAGE_ID=gcr.io/$GCLOUD_PROJECT/$IMAGE_NAME
+        fi
+
+        echo "IMAGE_ID=${IMAGE_ID}"
+        echo "VERSION=${VERSION}"
+
         if [[ "$CHECK_IMAGE_TAG" == "" ]]; then
           docker tag image $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION
         else
           gcloud container images add-tag -q  gcr.io/${GCLOUD_PROJECT}/${IMAGE_NAME}:${CHECK_IMAGE_TAG}  gcr.io/${GCLOUD_PROJECT}/${IMAGE_NAME}:$VERSION
         fi
+      env:
+        REGISTRY: "${{ inputs.registry }}"

--- a/.github/actions/docker-build-v2/action.yml
+++ b/.github/actions/docker-build-v2/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         # Set up docker to authenticate
         # via gcloud command-line tool.
-        gcloud auth configure-docker
+        gcloud auth configure-docker gcr.io,eu.gcr.io,europe-west3-docker.pkg.dev
 
     - name: Check if already an image built for the commit
       shell: bash


### PR DESCRIPTION
## Description

Ticket: [DEV-930](https://myos.atlassian.net/browse/DEV-930)

- Add a `registry` input defaulting to `container`
- Add possibility to upload to `artifact registry` to migrate service one by one

Tested the 2 cases: https://github.com/myos-finance/comment-service/pull/43
The idea will be to migrate all microservices repositories to push to artifact registry before cleaning up the `container registry` part and the condition.

[DEV-930]: https://myos.atlassian.net/browse/DEV-930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ